### PR TITLE
Rewrite !create-team

### DIFF
--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -1,4 +1,5 @@
 import logging
+import typing
 
 import asyncio, time
 
@@ -25,32 +26,29 @@ class UtilityCog(commands.Cog, name='Utility Commands'):
 
     @commands.command(name='create-team', help = help_text.create_team_HelpText.text, brief = help_text.create_team_HelpText.brief, usage = help_text.create_team_HelpText.usage)
     @checks.is_in_channels("commands")
-    async def create_team(self, ctx: commands.Context, *player_names):
+    @checks.has_any_role("admin_id", "member_id")
+    async def create_team(self, ctx: commands.Context, mv_bool: typing.Optional[bool], players_list: commands.Greedy[discord.Member]):
         logger.debug('!create-team command called')
-        member = await discord.ext.commands.MemberConverter().convert(ctx, ctx.message.author.name)
-        voice_channel = discord.utils.find(lambda x: member in x.members, ctx.message.guild.voice_channels)
-        # TODO Only the last element of list is taken!
-        voice_channel = voice_channel if voice_channel is not None else utility.get_voice_channel(ctx.message, self.bot.config.get_guild_config(ctx.guild.id).channel_ids.create_team_voice[0])
-        players_list = utility.get_players_in_channel(voice_channel)
-        if len(list(player_names)) != 0:
-            for player_name in player_names:
-                if player_name != 'mv':
-                    players_list.append(player_name)
-        message, team1, team2 = utility.create_team(players_list, utility.get_guild_config(self.bot, ctx.guild.id))
+
+        if ctx.author.voice is not None:
+            current_voice_channel = ctx.author.voice.channel
+            players_list += current_voice_channel.members
+
+        guild_config = utility.get_guild_config(self.bot, ctx.guild.id)
+
+        message, team1, team2 = utility.create_team(players_list, guild_config)
         await ctx.send(message)
 
-        role = discord.utils.find(lambda x: x.name == 'Wurzel', ctx.message.guild.roles)
-        if len(list(player_names)) == 0:
-            return
-
-        if player_names[0] == 'mv' and role in ctx.message.author.roles:
-            channel_team1 = discord.utils.find(lambda x: x.name == 'Team 1', ctx.message.guild.voice_channels)
-            channel_team2 = discord.utils.find(lambda x: x.name == 'Team 2', ctx.message.guild.voice_channels)
-            for member in voice_channel.members:
-                if member.name in team1:
-                    await member.move_to(channel_team1)
-                elif member.name in team2:
-                    await member.move_to(channel_team2)
+        if mv_bool:
+            channel_team1 = self.bot.get_channel(guild_config.channel_ids.team_1)
+            channel_team2 = self.bot.get_channel(guild_config.channel_ids.team_2)
+            
+            for member in players_list:
+                if member.voice is not None:
+                    if member in team1:
+                        await member.move_to(channel_team1)
+                    elif member in team2:
+                        await member.move_to(channel_team2)
 
     @commands.command(name='link', help = help_text.link_HelpText.text, brief = help_text.link_HelpText.brief, usage = help_text.link_HelpText.usage)
     @checks.is_riot_enabled

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -27,7 +27,7 @@ class UtilityCog(commands.Cog, name='Utility Commands'):
     @commands.command(name='create-team', help = help_text.create_team_HelpText.text, brief = help_text.create_team_HelpText.brief, usage = help_text.create_team_HelpText.usage)
     @checks.is_in_channels("commands")
     @checks.has_any_role("admin_id", "member_id")
-    async def create_team(self, ctx: commands.Context, mv_bool: typing.Optional[bool], players_list: commands.Greedy[discord.Member]):
+    async def create_team(self, ctx: commands.Context, mv_bool: typing.Optional[bool], players_list: commands.Greedy[typing.Union[discord.Member, str]]):
         logger.debug('!create-team command called')
 
         if ctx.author.voice is not None:
@@ -44,7 +44,7 @@ class UtilityCog(commands.Cog, name='Utility Commands'):
             channel_team2 = self.bot.get_channel(guild_config.channel_ids.team_2)
             
             for member in players_list:
-                if member.voice is not None:
+                if isinstance(member, discord.Member) and member.voice is not None:
                     if member in team1:
                         await member.move_to(channel_team1)
                     elif member in team2:

--- a/core/bot_utility.py
+++ b/core/bot_utility.py
@@ -19,7 +19,7 @@ def read_config_file(filename):
     return json.load(open(f'./config/{filename}.json', 'r'))
 
 
-def create_team(players: typing.List[discord.Member], guild_config: config.GuildConfig):
+def create_team(players: typing.List[typing.Union[discord.Member, str]], guild_config: config.GuildConfig):
     """ Creates two teams and returns a string, and the two teams as lists. """
     num_players = len(players)
     team1 = random.sample(players, int(num_players / 2))
@@ -31,11 +31,13 @@ def create_team(players: typing.List[discord.Member], guild_config: config.Guild
     teams_message = guild_config.messages.team_header
     teams_message += guild_config.messages.team_1
     for player in team1:
-        teams_message += player.mention + "\n"
+        name = player.mention if isinstance(player, discord.Member) else player
+        teams_message += name + "\n"
 
     teams_message += guild_config.messages.team_2
     for player in team2:
-        teams_message += player.mention + "\n"
+        name = player.mention if isinstance(player, discord.Member) else player
+        teams_message += name + "\n"
 
     return teams_message, team1, team2
 

--- a/core/bot_utility.py
+++ b/core/bot_utility.py
@@ -1,6 +1,7 @@
 import random
 import re
 import json
+import typing
 
 import discord
 
@@ -18,10 +19,11 @@ def read_config_file(filename):
     return json.load(open(f'./config/{filename}.json', 'r'))
 
 
-def create_team(players, guild_config: config.GuildConfig):
+def create_team(players: typing.List[discord.Member], guild_config: config.GuildConfig):
+    """ Creates two teams and returns a string, and the two teams as lists. """
     num_players = len(players)
     team1 = random.sample(players, int(num_players / 2))
-    team2 = players
+    team2 = players.copy()
 
     for player in team1:
         team2.remove(player)
@@ -29,11 +31,11 @@ def create_team(players, guild_config: config.GuildConfig):
     teams_message = guild_config.messages.team_header
     teams_message += guild_config.messages.team_1
     for player in team1:
-        teams_message += player + "\n"
+        teams_message += player.mention + "\n"
 
     teams_message += guild_config.messages.team_2
     for player in team2:
-        teams_message += player + "\n"
+        teams_message += player.mention + "\n"
 
     return teams_message, team1, team2
 

--- a/core/config.py
+++ b/core/config.py
@@ -94,6 +94,8 @@ class Channel_Ids:
 
     plots: int = None
     announcement: int = None
+    team_1: int = None
+    team_2: int = None
 
     create_team_voice: List[int] = dataclasses.field(default_factory=list)
     play_request: List[int] = dataclasses.field(default_factory=list)


### PR DESCRIPTION
Code is much cleaner now and uses [converters](https://discordpy.readthedocs.io/en/latest/ext/commands/commands.html#converters) but the command is also a little bit different:

1. To tell the command to move the players in the team channels you can now use an _optional_ argument that can be converted to a bool. Examples:
    - ``!create-team t member1 member2``: Will move the players
    - ``!create-team yes member1 member2``: Will move the players
    - ``!create-team f member1 member2`` Doesn't move the players
    - ``!create-team member1 member2`` Doesn't move the players
    - ``!create-team mv member1 member2`` **Doesn't move the players** and the bot will think that ``mv`` is a player name
2. If a player is written like [this](https://discordpy.readthedocs.io/en/latest/ext/commands/api.html?highlight=converter#discord.ext.commands.MemberConverter), they are mentioned in the team message and can be moved. Otherwise (of course) not.
3. Command is only avaible for users with the member_id
4. You will be moved to the channels even if you are not in the same voice channel like the user, that started the command.


Close #115