### PR TITLE
Reimplemented the purge command

### DIFF
--- a/cogs/cog_play_requests.py
+++ b/cogs/cog_play_requests.py
@@ -168,12 +168,12 @@ class PlayRequestsCog(commands.Cog, name="Play-Request Commands"):
         Handle messages sent by the bot to avoid race conditions.
 
         This is necessary, as the `send_to_channel` command creates a
-        pinned message, that could potentially be deleted if the control flow 
+        pinned message, that could potentially be deleted if the control flow
         after this function gets reached before the message is pinned.
         Only has meaning in combination with `DebugCog` or if
         the `self.bot.sending_message` attribute is changed.
         `ttl` determines how many seconds the bot has to send and pin a message.
-        Raises `RuntimeError` if the bot is not able send and pin a message in the 
+        Raises `RuntimeError` if the bot is not able send and pin a message in the
         given timeframe.
         """
         if message.author == self.bot.user:
@@ -183,7 +183,7 @@ class PlayRequestsCog(commands.Cog, name="Play-Request Commands"):
                 seconds_slept += 1
                 if seconds_slept > ttl:
                     raise RuntimeError("Waited for at least 10 seconds for sending_message to become False.")
-              
+
     @commands.Cog.listener()
     async def on_reaction_add(self, reaction: discord.Reaction, user: discord.Member):
         """

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -360,6 +360,15 @@ class UtilityCog(commands.Cog, name="Utility Commands"):
                 "There were too many highlights so some older highlights were not taken in account.", delete_after=10
             )
 
+    @commands.command(name='purge', hidden=True)
+    @commands.check(checks.is_super_user)
+    async def purge_(self, ctx, count: int):
+        logger.info("!purge %s called in channel %s", count, ctx.message.channel.name)
+        last_count_messages = await ctx.message.channel.history(limit=count + 1).flatten()
+        for message_ in last_count_messages:
+            if not message_.pinned:
+                await message_.delete()
+
 
 def setup(bot: DiscordBot.KrautBot):
     bot.add_cog(UtilityCog(bot))

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -363,7 +363,9 @@ class UtilityCog(commands.Cog, name="Utility Commands"):
     @commands.command(name="purge", hidden=True)
     @commands.check(checks.is_super_user)
     async def purge_(self, ctx: commands.Context, count: int):
-        logger.info(f"{self.bot.get_command_prefix(ctx.guild.id)}purge {count} called in channel {ctx.message.channel.name}")
+        logger.info(
+            f"{self.bot.get_command_prefix(ctx.guild.id)}purge {count} called in channel {ctx.message.channel.name}"
+        )
         last_count_messages = await ctx.message.channel.history(limit=count + 1).flatten()
         for message_ in last_count_messages:
             if not message_.pinned:

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -362,7 +362,7 @@ class UtilityCog(commands.Cog, name="Utility Commands"):
 
     @commands.command(name="purge", hidden=True)
     @commands.check(checks.is_super_user)
-    async def purge_(self, ctx, count: int):
+    async def purge_(self, ctx: commands.Context, count: int):
         logger.info("!purge %s called in channel %s", count, ctx.message.channel.name)
         last_count_messages = await ctx.message.channel.history(limit=count + 1).flatten()
         for message_ in last_count_messages:

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -363,7 +363,7 @@ class UtilityCog(commands.Cog, name="Utility Commands"):
     @commands.command(name="purge", hidden=True)
     @commands.check(checks.is_super_user)
     async def purge_(self, ctx: commands.Context, count: int):
-        logger.info("!purge %s called in channel %s", count, ctx.message.channel.name)
+        logger.info(f"{self.bot.get_command_prefix(ctx.guild.id)}purge {count} called in channel {ctx.message.channel.name}")
         last_count_messages = await ctx.message.channel.history(limit=count + 1).flatten()
         for message_ in last_count_messages:
             if not message_.pinned:

--- a/cogs/cog_utility.py
+++ b/cogs/cog_utility.py
@@ -360,7 +360,7 @@ class UtilityCog(commands.Cog, name="Utility Commands"):
                 "There were too many highlights so some older highlights were not taken in account.", delete_after=10
             )
 
-    @commands.command(name='purge', hidden=True)
+    @commands.command(name="purge", hidden=True)
     @commands.check(checks.is_super_user)
     async def purge_(self, ctx, count: int):
         logger.info("!purge %s called in channel %s", count, ctx.message.channel.name)


### PR DESCRIPTION
The purge command is reimplemented.
It is a hidden command, that can only be used by super_users, as we can check this manually now with `@commands.check(checks.is_super_user)`.
The actual command code is still the same as it was before removal: https://github.com/Susannova/Discord_Bot/commit/3bf83c8a388eecd1a3b401e3619b528a4e05b898